### PR TITLE
Added schema creation (postgres) if needed on first migration

### DIFF
--- a/lib/migrate/table-creator.js
+++ b/lib/migrate/table-creator.js
@@ -33,7 +33,7 @@ function ensureTable(tableName, schemaName, trxOrKnex) {
 }
 
 function _createMigrationTable(tableName, schemaName, trxOrKnex) {
-  return getSchemaBuilder(trxOrKnex, schemaName).createTable(
+  return getSchemaBuilder(trxOrKnex, schemaName).createSchemaIfNotExists(schemaName).createTable(
     getTableName(tableName),
     function (t) {
       t.increments();
@@ -45,7 +45,7 @@ function _createMigrationTable(tableName, schemaName, trxOrKnex) {
 }
 
 function _createMigrationLockTable(tableName, schemaName, trxOrKnex) {
-  return getSchemaBuilder(trxOrKnex, schemaName).createTable(
+  return getSchemaBuilder(trxOrKnex, schemaName).createSchemaIfNotExists(schemaName).createTable(
     tableName,
     function (t) {
       t.increments('index').primary();


### PR DESCRIPTION
fix a problem with first migration when you don't have schema yet.
Before you had a bug like this:
`error: create table "config"."knex_migrations" ("id" serial primary key, "name" varchar(255), "batch" integer, "migration_time" timestamptz) - schema "config" does not exist`